### PR TITLE
修复相册演技力百分比加成计算偏高

### DIFF
--- a/src/logic/ScoreCalculator.js
+++ b/src/logic/ScoreCalculator.js
@@ -91,21 +91,35 @@ export default class ScoreCalculator {
       if (!effect.canTrigger(this, -1)) return
       passiveEffects.album.push({effect, source:-1})
     })
+    const albumMemberTriggers = new Set([
+      'CharacterBase',
+      'Character',
+      'Company',
+      'Attribute',
+      'SenseType',
+      'CharacterBaseGroup',
+    ])
     this.extra.albumExtra.forEach(i => {
       if (!i.enabled) return
       const effect = i.effect
-      if (effect.Triggers.length === 0) {
-        passiveEffects.album.push({effect, source:-1})
+      const hasMemberTrigger = effect.Triggers.some(t => albumMemberTriggers.has(t.Trigger))
+      if (hasMemberTrigger) {
+        const targets = []
+        this.members.forEach((chara, idx) => {
+          if (!chara) return
+          if (!effect.canTrigger(this, idx)) return
+          targets.push(idx)
+        })
+        if (targets.length === 0) return
+        const originalRange = effect.Range
+        if (originalRange === 'All') effect.Range = 'Self'
+        targets.forEach(idx => effect.applyEffect(this, idx, StatBonusType.Album))
+        effect.Range = originalRange
         return
       }
-      let nonPassiveTriggered = false
-      this.members.forEach((chara, idx) => {
-        if (!chara) return
-        if (!effect.canTrigger(this, idx)) return
-        if (nonPassiveTriggered && effect.FireTimingType !== 'Passive') return
-        nonPassiveTriggered = true
-        passiveEffects.album.push({effect, source:idx})
-      })
+      if (effect.Triggers.length === 0 || effect.canTrigger(this, -1)) {
+        passiveEffects.album.push({effect, source:-1})
+      }
     })
     passiveEffects.album.forEach(i => i.effect.applyEffect(this, i.source, StatBonusType.Album))
 


### PR DESCRIPTION
问题：相册额外效果在带成员触发条件时，会被多次应用且范围过大，导致演技力百分比加成偏高。

修复：带“成员触发”的相册效果只对匹配成员逐个应用，不再按 `effect.Range = 'All'`对全员重复叠加；
没有成员触发的全局相册效果仍保持一次性应用。

说明：这修正了“属性/剧团/角色限定”的相册效果被全员多次加成的情况，从而消除了演技力百分比加成偏高的问题。

已与游戏中显示的实际演技力进行对照验证，确认计算出的数值达到了一致